### PR TITLE
Change dependency to use framework module only

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
 		"homepage": "http://jonathonmenz.com"
 	}],
 	"require": {
-		"silverstripe/cms": "^3.1"
+		"silverstripe/framework": "^3.1"
 	},
 	"extra": {
 		"installer-name": "text-target-length"


### PR DESCRIPTION
Hi there

Your module works find with SilverStripe framework only. It would be good to be able to used it without the CMS module.

Cheers