### PR TITLE
By default the length target was broken

### DIFF
--- a/code/TextTargetLengthExtension.php
+++ b/code/TextTargetLengthExtension.php
@@ -35,7 +35,7 @@ class TextTargetLengthExtension extends Extension
 		$field->setAttribute('data-target-min-length', $minCharCount);
 		$field->setAttribute('data-target-max-length', $maxCharCount);
 
-        $field->setAttribute('data-hint-length-target', _t('TextTargetLength.LengthTarget', 'Length target: <b>%s%</b> <i>%s</i>'));
+        $field->setAttribute('data-hint-length-target', _t('TextTargetLength.LengthTarget', 'Length target: <b>{value}%</b> <i>{remark}</i>'));
         $field->setAttribute('data-hint-length-tooshort', _t('TextTargetLength.LengthTooShort', 'Keep going!'));
         $field->setAttribute('data-hint-length-toolong', _t('TextTargetLength.LengthTooLong', 'Too long'));
         $field->setAttribute('data-hint-length-adequate', _t('TextTargetLength.LengthAdequate', 'Okay'));


### PR DESCRIPTION
The default string was broken on a not translated install