### PR TITLE
FIX typo

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -1,7 +1,7 @@
 ---
 Name: text-target-length
 ---
-SilverStripe\Forms\TextareaField:
+SilverStripe\Forms\TextField:
   extensions:
     - JonoM\SilverStripeTextTargetLength\TextTargetLengthExtension
 SilverStripe\Forms\TextareaField:


### PR DESCRIPTION
Typo in config, `TextField` has not been extended