### PR TITLE
FIX input-group display

### DIFF
--- a/client/css/text-target-length.css
+++ b/client/css/text-target-length.css
@@ -19,10 +19,5 @@
 	color: #e39d08;
 }
 .input-group p.target-length-count {
-    background: whitesmoke;
-    line-height: 27px;
-    padding: .25rem .50rem;
-    border-radius: 0 3px 3px 0;
-    border: 1px solid #cbd3df;
-    border-left: none;
+	width: 100%;
 }

--- a/client/css/text-target-length.css
+++ b/client/css/text-target-length.css
@@ -18,3 +18,11 @@
 .target-length p.target-length-count.under b {
 	color: #e39d08;
 }
+.input-group p.target-length-count {
+    background: whitesmoke;
+    line-height: 27px;
+    padding: .25rem .50rem;
+    border-radius: 0 3px 3px 0;
+    border: 1px solid #cbd3df;
+    border-left: none;
+}


### PR DESCRIPTION
Fixes display of text when rendered within an `.input-group` (parent has `flex`)

![image](https://user-images.githubusercontent.com/13566916/38798785-e8b0122e-41a5-11e8-87c5-2848b509deae.png)
