### PR TITLE
Allow SS6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "homepage": "http://jonathonmenz.com"
     }],
     "require": {
-        "silverstripe/framework": "^4.0 || ^5.0"
+        "silverstripe/framework": "^4.0 || ^5.0 || ^6.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Setting Composer to allow installation with SS6.0.  Looked through everything else and did not see any conflicts from the new API changes